### PR TITLE
Fix/pubblication error

### DIFF
--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'maven-publish'
+    id 'com.gradle.plugin-publish' version '0.18.0'
     id 'groovy'
 }
 
@@ -11,8 +11,8 @@ repositories {
     gradlePluginPortal()
 }
 
-group = 'com.empatica'
-version = '1.4.0'
+group = "$PUBLISH_GROUP_ID"
+version = "$PUBLISH_VERSION"
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
@@ -25,19 +25,25 @@ dependencies {
 pluginBundle {
     website = 'https://github.com/kezong/fat-aar-android'
     vcsUrl = 'https://github.com/kezong/fat-aar-android.git'
-    plugins {
-        fataar {
-            displayName = 'FatAar'
-            description = 'A gradle plugin that merge dependencies into the final aar file'
-        }
-    }
 }
 
 gradlePlugin {
     plugins {
         fataar {
+            displayName = 'FatAar'
+            description = 'A gradle plugin that merge dependencies into the final aar file'
             id = 'com.empatica.fat-aar'
             implementationClass = 'com.kezong.fataar.FatAarPlugin'
         }
     }
 }
+
+publishing {
+    repositories {
+        maven {
+            name = 'fat-aar-android'
+            url = '/Users/mattiapini/Desktop/fat-aar-adndroid'
+        }
+    }
+}
+

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -11,7 +11,7 @@ repositories {
     gradlePluginPortal()
 }
 
-group = 'com.github.kezong'
+group = 'com.empatica'
 version = '1.4.0'
 
 dependencies {
@@ -36,7 +36,7 @@ pluginBundle {
 gradlePlugin {
     plugins {
         fataar {
-            id = 'com.kezong.fat-aar'
+            id = 'com.empatica.fat-aar'
             implementationClass = 'com.kezong.fataar.FatAarPlugin'
         }
     }

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -42,7 +42,7 @@ publishing {
     repositories {
         maven {
             name = 'fat-aar-android'
-            url = '/Users/mattiapini/Desktop/fat-aar-adndroid'
+            url = '../fat-aar-adndroid'
         }
     }
 }

--- a/source/gradle.properties
+++ b/source/gradle.properties
@@ -1,3 +1,3 @@
-PUBLISH_GROUP_ID=com.empatica
+PUBLISH_GROUP_ID=com.github.empatica
 PUBLISH_ARTIFACT_ID=fat-aar
 PUBLISH_VERSION=1.4.0

--- a/source/gradle.properties
+++ b/source/gradle.properties
@@ -1,3 +1,3 @@
-PUBLISH_GROUP_ID=com.github.kezong
+PUBLISH_GROUP_ID=com.empatica
 PUBLISH_ARTIFACT_ID=fat-aar
 PUBLISH_VERSION=1.4.0


### PR DESCRIPTION
This PR aims to bring a personalization about the gradle

It renames `groupId` and `artifactId`, taking in account empatica as a base

(If we want to make this modification public, we should take in account to put them back with the original name)
